### PR TITLE
Fix crash on Java 11

### DIFF
--- a/src/main/scala/li/cil/oc/common/SaveHandler.scala
+++ b/src/main/scala/li/cil/oc/common/SaveHandler.scala
@@ -225,19 +225,8 @@ object SaveHandler {
       // Touch all externally saved data when loading, to avoid it getting
       // deleted in the next save (because the now - save time will usually
       // be larger than the time out after loading a world again).
-      if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_7)) SaveHandlerJava17Functionality.visitJava17(statePath)
-      else visitJava16()
+      SaveHandlerJava17Functionality.visitJava17(statePath)
     }
-  }
-
-  private def visitJava16() {
-    // This may run into infinite loops if there are evil symlinks.
-    // But that's really not something I'm bothered by, it's a fallback.
-    def recurse(file: File) {
-      file.setLastModified(System.currentTimeMillis())
-      if (file.exists() && file.isDirectory && file.list() != null) file.listFiles().foreach(recurse)
-    }
-    recurse(statePath)
   }
 
   @SubscribeEvent(priority = EventPriority.LOWEST)


### PR DESCRIPTION
The `SystemUtils.isJavaVersionAtLeast` method provided by Apache Commons crashes on newer versions of Java (refer to https://issues.apache.org/jira/browse/LANG-1384). Presumably Mojang does not ship a version of Commons with the upstream fix included. It does work on Java 8 but I prefer to use Java 11 when possible.

As the only usage of it here is to detect Java 7 or later, and we know Minecraft requires Java 8, the check can be removed entirely.